### PR TITLE
build: add package command to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -93,6 +93,8 @@ _usage() {
     echo "Commands:"
     echo "    configure  Configure build settings"
     echo "    build      Build the entire project"
+    echo "    install    Install the project to the configured prefix"
+    echo "    package    Build distributable packages using CPack"
     echo "    test       Perform unit tests"
     echo "    clean      Delete all files that are created by building the program"
     echo "    distclean  Delete all files that are created by configuring or building the program"
@@ -207,7 +209,7 @@ _configure() {
     if [ "${ENABLE_YAML}" != "AUTO" ]; then
         FEATURES="${FEATURES} -DENABLE_YAML=${ENABLE_YAML}"
     fi
-    if [ "${VERBOSE}" == "ON" ]; then
+    if [ "${VERBOSE}" = "ON" ]; then
         FEATURES="${FEATURES} -DCMAKE_VERBOSE_MAKEFILE=TRUE"
     fi
 
@@ -263,6 +265,14 @@ _install() {
 
 _clean() {
     ${CMAKE} --build ${BUILD_DIR} --target clean
+}
+
+_package() {
+    if [ ! -f "${BUILD_DIR}/CPackConfig.cmake" ]; then
+        echo "Project is not configured. Run './${SCRIPT_NAME} configure' first." 1>&2
+        exit 1
+    fi
+    (cd "${BUILD_DIR}" && cpack)
 }
 
 _distclean()
@@ -324,6 +334,9 @@ case "${COMMAND}" in
         ;;
     clean)
         _clean "$@"
+        ;;
+    package)
+        _package "$@"
         ;;
     distclean)
         _distclean "$@"


### PR DESCRIPTION
Fixes #78

This PR adds support for a `package` command in build.sh.

The new command invokes CPack from the build directory to generate
distributable artifacts and is wired into the existing CLI dispatcher.
The help output has been updated to document both install and package
commands.

Additionally, a POSIX shell compatibility issue was fixed by replacing
`==` with `=` in a test expression, which removes a runtime warning.
Packaging works after running `configure`, as CPack internally triggers
the required install targets.
